### PR TITLE
[APP-3395] Fix missing params condition & add autostopping readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ Lastly, scroll to the top of the application source and click **Build applicatio
 To test the bot, navigate to your Slack chat and use @-mention: `@testbot Hello!`. Be sure to use your own bot username and to invite them to the public channel that you're testing within.
 If the @-mention worked, you can also verify the messages sample by saying `hello` or `bye`.
 
+### Disable auto-stopping
+
+Custom applications auto-stop after a while of inactivity. To turn this off for your Slack bot, please run the following
+command using your `<application_id>` and `<authorization_token>`:
+
+```shell
+curl --location --request PATCH 'https://app.datarobot.com/api/v2/customApplications/<application_id>/' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: <authorization_token>' \
+--data '{
+    "allowAutoStopping": false
+}'
+```
+
 ## Add more actions
 
 You can find examples for all available Slack listeners in the [Bolt for Python starter template](https://github.com/slack-samples/bolt-python-starter-template/tree/main). The approach is the exact same as in this repository, but they provide other, more advanced actions.

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -38,7 +38,8 @@
     <ul>
         {% if not has_bot_token %}
         <li class="bold">SLACK_BOT_TOKEN</li>
-        {% elif not has_app_token %}
+        {% endif %}
+        {% if not has_app_token %}
         <li class="bold">SLACK_APP_TOKEN</li>
         {% endif %}
     </ul>

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
     ],
     "source": {
       "repositoryUrl": "https://github.com/datarobot-oss/slack-bot-app",
-      "releaseTag": "10.2.3"
+      "releaseTag": "10.2.4"
     },
     "previewImage": null
   },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

When env params were missing it only showed 1 missing not all
Add readme for disabling autostop
