### PR TITLE
[APP-3492] Slack Bot: Cut 11.0 tag for template main branch

### DIFF
--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
     ],
     "source": {
       "repositoryUrl": "https://github.com/datarobot-oss/slack-bot-app",
-      "releaseTag": "11.0"
+      "releaseTag": "11.0.0"
     },
     "previewImage": null
   },

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
     ],
     "source": {
       "repositoryUrl": "https://github.com/datarobot-oss/slack-bot-app",
-      "releaseTag": "10.2.6"
+      "releaseTag": "11.0"
     },
     "previewImage": null
   },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

10.2 Branch runs separately, main should now continue with 11.0 tag

