### PR TITLE
Fix Curl Command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ command using your `<application_id>` and `<authorization_token>`:
 ```shell
 curl --location --request PATCH 'https://app.datarobot.com/api/v2/customApplications/<application_id>/' \
 --header 'Content-Type: application/json' \
---header 'Authorization: <authorization_token>' \
+--header 'Authorization: Bearer <authorization_token>' \
 --data '{
     "allowAutoStopping": false
 }'


### PR DESCRIPTION
This had me confused for a while trying out several different keys and running around the docs to see what I was doing wrong when it turns out it was just missing "Bearer" in the header.

Feel free to close this and update your own docs internally since I'm a DataRobot employee anyway. I wasn't sure where the right place to suggest the update was

## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

_What is this pull request for?_

Fix a bug in the docs that threw me for a loop

### Summary of Changes

Corrected the headers in the sample curl command to turn off autoStopping
